### PR TITLE
Syncing perps market createMarket event name + fixing market id arg

### DIFF
--- a/cannonfile.toml
+++ b/cannonfile.toml
@@ -5,6 +5,9 @@ description = "Synthetix Sandbox"
 [setting.user]
 defaultValue="0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
 
+[setting.ethPerpMarketId]
+defaultValue="100"
+
 [setting.synthetix]
 defaultValue="synthetix:latest"
 
@@ -279,8 +282,8 @@ depends = ["provision.perpsMarket"]
 target = ["perpsMarket.PerpsMarketProxy"]
 func = "createMarket"
 from = "<%= settings.user %>"
-args = ["Ethereum", "ETH", "<%= settings.user %>"]
-extra.perpsMarketId.event = "MarketRegistered"
+args = ["<%= settings.ethPerpMarketId %>", "ETH", "<%= settings.user %>"]
+extra.perpsMarketId.event = "MarketCreated"
 extra.perpsMarketId.arg = 0
 depends = ["invoke.allowCreatePerpsAccount"]
 


### PR DESCRIPTION
![image](https://github.com/Synthetixio/synthetix-sandbox/assets/30664234/be2f8124-5821-4377-ba10-7159cf8c65b1)

This error was popping up before due to the createMarket event name changing from 'MarketRegistered' to 'MarketCreated' .

Also the first arg of the createMarket func invoke call was incorrect before.