### PR TITLE
Fix import paths in cannonfile.prod.toml

### DIFF
--- a/cannonfile.prod.toml
+++ b/cannonfile.prod.toml
@@ -8,7 +8,7 @@ source ="synthetix-omnibus:3.3.4"
 [contract.sample_integration]
 artifact = "SampleIntegration"
 args = [
-    "<%= imports.synthetixOmnibus.contracts.system.CoreProxy %>",
-    "<%= imports.synthetixOmnibus.contracts.system.USDProxy %>"
+    "<%= imports.synthetixOmnibus.imports.system.CoreProxy.address %>",
+    "<%= imports.synthetixOmnibus.imports.system.USDProxy.address %>"
 ]
 depends = ["import.synthetixOmnibus"]


### PR DESCRIPTION
Currently when running this, you get the error `TypeError: Cannot read properties of undefined (reading 'CoreProxy')`.

This update makes the paths match what they should be.